### PR TITLE
:memo: Add Links to the user manual and assembly guide

### DIFF
--- a/_modules/DIV.md
+++ b/_modules/DIV.md
@@ -11,9 +11,9 @@ documentation:
   modulargrid: https://www.modulargrid.net/e/other-unknown-mopsy-div
   others:
     - label: User Manual v1.1
-      url:
+      url: https://github.com/moPsy-project/div/releases/download/v1.1/DIV_User_Manual.pdf
     - label: Assembly Guide v1.1
-      url:
+      url: https://github.com/moPsy-project/div/releases/download/v1.1/DIV_v1.1_Assembly_Guide.pdf
 availability:
   # Lifecycles: concept, dev, prod, discontinued
   lifecycle: prod


### PR DESCRIPTION
Somehow this got lost with the GitHub outage