### PR TITLE
:construction_worker: Change link checker action to check compiled page

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,6 +15,8 @@ jobs:
         - name: Link Checker
           id: lychee
           uses: lycheeverse/lychee-action@v1.8.0
+          with:
+            args: --verbose https://www.mopsy-music.de
 
         - name: Create Issue From File
           if: env.lychee_exit_code != 0


### PR DESCRIPTION
lychee seems to have trouble with Jekyll (as in: does not understand jekyll), so we have to point it to the compiled site.