### PR TITLE
Tweak Link Checker Action

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -16,7 +16,7 @@ jobs:
           id: lychee
           uses: lycheeverse/lychee-action@v1.8.0
           with:
-            args: --verbose https://www.mopsy-music.de
+            args: --verbose https://www.mopsy-music.de --exclude "https://www.patreon.com/penguineer"
 
         - name: Create Issue From File
           if: env.lychee_exit_code != 0

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
-    - cron: "00 18 * * *"
+    - cron: "0 6 * * 5"
 
 jobs:
     linkChecker:


### PR DESCRIPTION
Tweak the link checker in response to the current performance:

* Run only check once a week
* Exclude Patreon from checking based on #35, #43, #44, #45

Further investigation is needed, see #46