### PR TITLE
Extend copyright to 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When you are done, do not forget to remove the deployment with `docker-compose d
 
 ## License
 
-© 2022-2024 Stefan Haun
+© 2022-2025 Stefan Haun
 
 Uses [Skeleton](https://github.com/dhg/Skeleton/) with the [MIT License](MIT.md).
 

--- a/_layouts/frame.html
+++ b/_layouts/frame.html
@@ -71,7 +71,7 @@
 <footer>
 <div class="row">
     <div class="eight columns">
-      <span>&copy; 2022-2023 Stefan Haun</span>
+      <span>&copy; 2022-2025 Stefan Haun</span>
     </div>
     <div class="two columns">
         <nav>


### PR DESCRIPTION
This pull request updates copyright years across the project to reflect the new range of 2022-2025.

### Copyright updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the copyright year from 2022-2024 to 2022-2025.
* [`_layouts/frame.html`](diffhunk://#diff-5471cb20953928c27f0bd6511ef48fd61debf00aa6cdcb6332e26a8268178bd8L74-R74): Updated the copyright year in the footer from 2022-2023 to 2022-2025.