### PR TITLE
Remove obsolete version field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   jekyll:
       image: jekyll/jekyll:4


### PR DESCRIPTION
This PR removes the obsolete `version` field from the docker-compose file.